### PR TITLE
add link to gh-pages diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ Hello PWA has been tested in the following browsers:
 * Firefox 60
 * Safari 11
 * Edge 42
+
+## GitHub Pages
+
+A couple of changes are needed to host this app with GitHub Pages. This is because the app is hosted from a domain subfolder. 
+
+View the changes here: [Comparing master...gh-pages · jamesjohnson280/hello-pwa](https://github.com/jamesjohnson280/hello-pwa/compare/master...gh-pages).


### PR DESCRIPTION
Hi James, 

Really good PWA tutorial, I like the minimalist, no-dependencies approach!

Took me a while (and some hair-pulling) to notice that some changes are needed from the version in your medium post to  deploy this on GitHub pages. I think pointing out those differences somewhere would help - I've just added a link to the README. 

What do you think?

Cheers, 

Stu