### PR TITLE
Make relative paths possible

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Hello World</title>
-  <link rel="manifest" href="/manifest.json">
+  <link rel="manifest" href="./manifest.json">
   <link rel="stylesheet" href="css/style.css">
   <link rel="icon" href="favicon.ico" type="image/x-icon" />
   <link rel="apple-touch-icon" href="images/hello-icon-152.png">

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
       "type": "image/png"
     }],
   "lang": "en-US",
-  "start_url": "/index.html",
+  "start_url": "./index.html",
   "display": "standalone",
   "background_color": "white",
   "theme_color": "white"

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 var cacheName = 'hello-pwa';
 var filesToCache = [
-  '/',
-  '/index.html',
-  '/css/style.css',
-  '/js/main.js'
+  './',
+  './index.html',
+  './css/style.css',
+  './js/main.js'
 ];
 
 /* Start the service worker and cache all of the app's content */


### PR DESCRIPTION
in case someone has her local server set up in a way that /Hello-PWA is not the document root  (but e.g. /, so that one would access http://127.0.0.1/HelloPWA/index.html instead of just http://127.0.0.1/index.html ) this allows to run the PWA nevertheless, independent from the path: otherwise the manifest is looked up from the wrong URL, the service worker has the wrong URL and the start_url in the manifest is also incorrect.